### PR TITLE
Add check if contao/news-bundle is installed in OutputFrontendTemplateListener

### DIFF
--- a/src/EventListener/OutputFrontendTemplateListener.php
+++ b/src/EventListener/OutputFrontendTemplateListener.php
@@ -70,15 +70,13 @@ class OutputFrontendTemplateListener
             // check if current page is a newsreader
             $alias = Input::get('auto_item');
 
-            if (isset($alias)) {
-				if (InstalledVersions::isInstalled('contao/news-bundle')) {
-					$newsModel = NewsModel::findBy('alias', $alias);
+            if (isset($alias) && InstalledVersions::isInstalled('contao/news-bundle')) {
+  	        $newsModel = NewsModel::findBy('alias', $alias);
 
-					if (null !== $newsModel) {
-						$mainKeyword = $newsModel->contaoSeoMainKeyword;
-						$secondaryKeywords = $newsModel->contaoSeoSecondaryKeywords;
-					}
-                }
+		if (null !== $newsModel) {
+		    $mainKeyword = $newsModel->contaoSeoMainKeyword;
+		    $secondaryKeywords = $newsModel->contaoSeoSecondaryKeywords;
+		}
             }
 
             $engines = json_encode(StringUtil::deserialize($rootPage->contaoSeoIndexNowEngines));

--- a/src/EventListener/OutputFrontendTemplateListener.php
+++ b/src/EventListener/OutputFrontendTemplateListener.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Pdir\ContaoSeoPlugin\EventListener;
 
+use Composer\InstalledVersions;
 use Contao\BackendUser;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Input;
@@ -70,11 +71,13 @@ class OutputFrontendTemplateListener
             $alias = Input::get('auto_item');
 
             if (isset($alias)) {
-                $newsModel = NewsModel::findBy('alias', $alias);
+				if (InstalledVersions::isInstalled('contao/news-bundle')) {
+					$newsModel = NewsModel::findBy('alias', $alias);
 
-                if (null !== $newsModel) {
-                    $mainKeyword = $newsModel->contaoSeoMainKeyword;
-                    $secondaryKeywords = $newsModel->contaoSeoSecondaryKeywords;
+					if (null !== $newsModel) {
+						$mainKeyword = $newsModel->contaoSeoMainKeyword;
+						$secondaryKeywords = $newsModel->contaoSeoSecondaryKeywords;
+					}
                 }
             }
 

--- a/src/EventListener/OutputFrontendTemplateListener.php
+++ b/src/EventListener/OutputFrontendTemplateListener.php
@@ -70,7 +70,7 @@ class OutputFrontendTemplateListener
             // check if current page is a newsreader
             $alias = Input::get('auto_item');
 
-            if (isset($alias) && InstalledVersions::isInstalled('contao/news-bundle')) {
+            if (\isset($alias) && InstalledVersions::isInstalled('contao/news-bundle')) {
   	        $newsModel = NewsModel::findBy('alias', $alias);
 
 		if (null !== $newsModel) {
@@ -79,7 +79,7 @@ class OutputFrontendTemplateListener
 		}
             }
 
-            $engines = json_encode(StringUtil::deserialize($rootPage->contaoSeoIndexNowEngines));
+            $engines = \json_encode(StringUtil::deserialize($rootPage->contaoSeoIndexNowEngines));
 
             $GLOBALS['TL_JAVASCRIPT'][] = $this->assetsDir . '/js/toolbar.js';
             $GLOBALS['TL_CSS'][] = $this->assetsDir . '/scss/toolbar.scss|static';


### PR DESCRIPTION
NewsModel might not be available, because the Contao News Bundle is not required by this bundle.
If it is not installed the following error will occur if auto_item is set: 
```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError:
Attempted to load class "NewsModel" from namespace "Contao".
Did you forget a "use" statement for another namespace?

  at vendor/pdir/contao-seo-plugin/src/EventListener/OutputFrontendTemplateListener.php:74
  at Pdir\ContaoSeoPlugin\EventListener\OutputFrontendTemplateListener->__invoke()
     (vendor/contao/core-bundle/contao/classes/FrontendTemplate.php:96)
  at Contao\FrontendTemplate->compile()
     (vendor/contao/core-bundle/contao/classes/FrontendTemplate.php:69)
  at Contao\FrontendTemplate->getResponse()
     (vendor/contao/core-bundle/contao/pages/PageRegular.php:49)
  at Contao\PageRegular->getResponse()
     (vendor/contao/core-bundle/contao/controllers/FrontendIndex.php:65)
  at Contao\FrontendIndex->renderPage()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)    
```

This PR adds a check if the News Bundle is installed and thus fixes the error.